### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,15 +12,15 @@ RunLoop	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-RunLoopObject                                    KEYWORD2
-RunLoopTimer                                     KEYWORD2
-RunLoopHardwareTimer                             KEYWORD2
-RunLoopHardwareTimer0                            KEYWORD2
-RunLoopHardwareTimer1                            KEYWORD2
-RunLoopHardwareTimer2                            KEYWORD2
-RunLoopHardwareTimer3                            KEYWORD2
-RunLoopHardwareTimer4                            KEYWORD2
-RunLoopHardwareTimer5                            KEYWORD2
+RunLoopObject	KEYWORD2
+RunLoopTimer	KEYWORD2
+RunLoopHardwareTimer	KEYWORD2
+RunLoopHardwareTimer0	KEYWORD2
+RunLoopHardwareTimer1	KEYWORD2
+RunLoopHardwareTimer2	KEYWORD2
+RunLoopHardwareTimer3	KEYWORD2
+RunLoopHardwareTimer4	KEYWORD2
+RunLoopHardwareTimer5	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords